### PR TITLE
Solve Bug #113563 for POE-Component-Client-DNS: Test::More and Test::…

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,6 +7,8 @@ license           = Perl_5
 [Prereqs]
 POE              = 1.294
 Net::DNS         = 0.65
+
+[Prereqs / TestRequires]
 Test::More       = 0.96
 Test::NoWarnings = 1.02
 


### PR DESCRIPTION
…NoWarnings should be ...

Done as suggested in https://rt.cpan.org/Public/Bug/Display.html?id=113563
