### PR TITLE
Resolve #148718 deprecated Net::DNS rdatastr() method

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license           = Perl_5
 
 [Prereqs]
 POE              = 1.294
-Net::DNS         = 0.65
+Net::DNS         = 0.69
 Test::More       = 0.96
 Test::NoWarnings = 1.02
 

--- a/lib/POE/Component/Client/DNS.pm
+++ b/lib/POE/Component/Client/DNS.pm
@@ -622,7 +622,7 @@ POE::Component::Client::DNS - non-blocking, parallel DNS client
       print(
         "$response->{host} = ",
         $answer->type(), " ",
-        $answer->rdatastr(), "\n"
+        $answer->rdstring(), "\n"
       );
     }
   }

--- a/t/01_resolve.t
+++ b/t/01_resolve.t
@@ -104,7 +104,7 @@ sub client_got_response {
   $heap->{answers}++;
 
   foreach (@answers) {
-    my $response_data_string = $_->rdatastr;
+    my $response_data_string = $_->rdstring;
     my $response_data_type   = $_->type;
 
     DEBUG and warn

--- a/t/06_hosts.t
+++ b/t/06_hosts.t
@@ -140,7 +140,7 @@ sub a_data {
 
   return (
     grep { ref() eq "Net::DNS::RR::A" } $response->{response}->answer()
-  )[0]->rdatastr();
+  )[0]->rdstring();
 }
 
 
@@ -149,7 +149,7 @@ sub aaaa_data {
   return "" unless defined $response->{response};
   return (
     grep { ref() eq "Net::DNS::RR::AAAA" } $response->{response}->answer()
-  )[0]->rdatastr();
+  )[0]->rdstring();
 }
 
 


### PR DESCRIPTION
rdstring() was added to Net::DNS 0.69 and rdatastr() was deprecated.

Net::DNS 1.38 added deprecation warnings for rdatastr() which are triggering Test::NoWarnings :(

It's a manual process to install this module now because of the test failures.